### PR TITLE
Rename keypop repo to .github

### DIFF
--- a/otterdog/eclipse-keypop.jsonnet
+++ b/otterdog/eclipse-keypop.jsonnet
@@ -19,7 +19,8 @@ orgs.newOrg('eclipse-keypop') {
     web_commit_signoff_required: false,
   },
   _repositories+:: [
-    orgs.newRepo('keypop') {
+    orgs.newRepo('.github') {
+      aliases: ["keypop"],
       allow_update_branch: false,
       web_commit_signoff_required: false,
     },


### PR DESCRIPTION
Due to https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3534